### PR TITLE
publicize KeyCodeTransformer.shared

### DIFF
--- a/Lib/Magnet/KeyCodeTransformer.swift
+++ b/Lib/Magnet/KeyCodeTransformer.swift
@@ -11,7 +11,7 @@ import Carbon
 
 open class KeyCodeTransformer {
     // MARK: - Properties
-    static let shared = KeyCodeTransformer()
+    public static let shared = KeyCodeTransformer()
 }
 
 // MARK: - Transform


### PR DESCRIPTION
`KeyCodeTransformer.shared` wasn't accessible from outside for no apparent reason. Also, there is no public initializer, so you simply cannot use `KeyCodeTransformer` in client code at all at the moment, making it pointless to publicize the type.

Since `KeyCodeTransformer` does not have state, I guess it'd be a better fit to make the methods static functions instead, just like `KeyTransformer` has them. 

What do you think?