### PR TITLE
Make CGEventFlags.contains public.

### DIFF
--- a/Lib/Magnet/HotKeyCenter.swift
+++ b/Lib/Magnet/HotKeyCenter.swift
@@ -215,8 +215,8 @@ private extension HotKeyCenter {
 }
 
 // MARK: - CGEventFlags
-private extension CGEventFlags {
-    func contains(_ flags: CGEventFlags) -> Bool {
+public extension CGEventFlags {
+    public func contains(_ flags: CGEventFlags) -> Bool {
         return rawValue & flags.rawValue == flags.rawValue
     }
 }


### PR DESCRIPTION
```
error: Magnet.CGEventFlags:2:17: error: method 'contains' must be declared public because it matches a requirement in public protocol 'SetAlgebra'
```