### PR TITLE
Conform `KeyCombo` to `Codable`

### DIFF
--- a/Lib/Magnet/KeyCombo.swift
+++ b/Lib/Magnet/KeyCombo.swift
@@ -9,7 +9,7 @@
 import Cocoa
 import Carbon
 
-public final class KeyCombo: NSObject, NSCopying, NSCoding {
+public final class KeyCombo: NSObject, NSCopying, NSCoding, Codable {
 
     // MARK: - Properties
     public let keyCode: Int


### PR DESCRIPTION
The actual conformance is auto-synthesized by the compiler, so this is all that's needed. I need Codable conformance so I can easily persist the key combo.