### PR TITLE
fix crash when compiled with xcode10 / swift4.2 due to randomly seeded hash values.

### DIFF
--- a/Lib/Magnet/HotKeyCenter.swift
+++ b/Lib/Magnet/HotKeyCenter.swift
@@ -163,6 +163,7 @@ private extension HotKeyCenter {
     }
 }
 
+
 // MARK: - Double Tap Modifier Event
 private extension HotKeyCenter {
     func sendModifiersEvent(_ event: CGEvent) -> Unmanaged<CGEvent>? {
@@ -174,7 +175,7 @@ private extension HotKeyCenter {
         let altTapped = flags.contains(.maskAlternate)
 
         // Only one modifier key
-        let totalHash = commandTapped.hashValue + altTapped.hashValue + shiftTapped.hashValue + controlTapped.hashValue
+        let totalHash = commandTapped.intValue + altTapped.intValue + shiftTapped.intValue + controlTapped.intValue
         if totalHash == 0 { return Unmanaged.passUnretained(event) }
         if totalHash > 1 {
             multiModifiers = true
@@ -220,4 +221,11 @@ private extension HotKeyCenter {
             .filter { $0.keyCombo.doubledModifiers && $0.keyCombo.modifiers == key }
             .forEach { $0.invoke() }
     }
+}
+
+
+extension Bool {
+  var intValue: Int {
+    return (self as NSNumber).intValue
+  }
 }

--- a/Lib/Magnet/KeyTransformer.swift
+++ b/Lib/Magnet/KeyTransformer.swift
@@ -64,7 +64,7 @@ public extension KeyTransformer {
         let optionSelected  = (carbonFlags & optionKey) != 0
         let controlSelected = (carbonFlags & controlKey) != 0
         let shiftSelected   = (carbonFlags & shiftKey) != 0
-        let hash = commandSelected.hashValue + optionSelected.hashValue + controlSelected.hashValue + shiftSelected.hashValue
+        let hash = commandSelected.intValue + optionSelected.intValue + controlSelected.intValue + shiftSelected.intValue
         return hash == 1
     }
 
@@ -73,7 +73,7 @@ public extension KeyTransformer {
         let optionSelected  = cocoaFlags.contains(.option)
         let controlSelected = cocoaFlags.contains(.control)
         let shiftSelected   = cocoaFlags.contains(.shift)
-        let hash = commandSelected.hashValue + optionSelected.hashValue + controlSelected.hashValue + shiftSelected.hashValue
+        let hash = commandSelected.intValue + optionSelected.intValue + controlSelected.intValue + shiftSelected.intValue
         return hash == 1
     }
 }


### PR DESCRIPTION
Crashes when compiled with recent versions of Xcode 10 beta were found to be due to code calling `.hashValue` to boolean values in order to obtain simple counts. 

Hash values are not intended to map reliably to Bool values, but up until now it seems `Bool.hashValue` was implemented such that they could be mistakenly used this way. There are changes coming with Swift 4.2 that now invalidate this usage. https://forums.swift.org/t/psa-the-stdlib-now-uses-randomly-seeded-hash-values/10789 has more details.

Fixed by adding an extension to use `NSNumber.intValue`.