### PR TITLE
expose keyEquivalent and fix uppercase-letter error

### DIFF
--- a/Lib/Magnet/KeyCodeTransformer.swift
+++ b/Lib/Magnet/KeyCodeTransformer.swift
@@ -25,6 +25,18 @@ extension KeyCodeTransformer {
     }
 
     fileprivate func transformValue(_ keyCode: Int, modifiers: Int) -> String {
+        return keyEquivalent(keyCode, modifiers: modifiers).uppercased()
+    }
+
+    public func keyEquivalent(_ keyCode: Int, carbonModifiers: Int) -> String {
+        return keyEquivalent(keyCode, modifiers: carbonModifiers)
+    }
+
+    public func keyEquivalent(_ keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String {
+        return keyEquivalent(keyCode, modifiers: KeyTransformer.carbonFlags(from: cocoaModifiers))
+    }
+
+    fileprivate func keyEquivalent(_ keyCode: Int, modifiers: Int) -> String {
         // Return Special KeyCode
         if let unmappedString = transformSpecialKeyCode(keyCode) {
             return unmappedString
@@ -55,7 +67,7 @@ extension KeyCodeTransformer {
 
         if error != noErr { return "" }
 
-        return NSString(characters: &chars, length: length).uppercased
+        return NSString(characters: &chars, length: length) as String
     }
 
     fileprivate func transformSpecialKeyCode(_ keyCode: Int) -> String? {


### PR DESCRIPTION
This is useful API to use Magnet's conversion algorithms e.g. for (de)serializing user defaults.

During the process of storing shortcuts in the defaults, I noticed that the string was uppercased. That's nice for displaying, but not for serialization, because shortcuts are case sensitive. (Uppercasing "n" to "N" will result in <kbd>⌘⇧N </kbd> instead of <kbd>⌘N</kbd>)