### PR TITLE
Change the save to KeyCode or Key to support special keys

### DIFF
--- a/Lib/Magnet.xcodeproj/project.pbxproj
+++ b/Lib/Magnet.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		099F2A07246D094500992925 /* ModifierEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099F2A04246D094500992925 /* ModifierEventHandlerTests.swift */; };
 		09DEE124245B128C00169BEC /* Sauce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 091D85CF2459553A00930473 /* Sauce.framework */; };
 		FA3AA2162315A6A3007EAA1F /* CollectionExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3AA2152315A6A3007EAA1F /* CollectionExtensionTests.swift */; };
+		FADEA45A24796103003AEC83 /* v3_1_0KeyCombo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADEA45924796103003AEC83 /* v3_1_0KeyCombo.swift */; };
 		FAEC34B31C9059DF004177E2 /* Magnet.h in Headers */ = {isa = PBXBuildFile; fileRef = FAEC34B21C9059DF004177E2 /* Magnet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FAEC34BA1C9059DF004177E2 /* Magnet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAEC34AF1C9059DF004177E2 /* Magnet.framework */; };
 		FAEC34D81C905B4D004177E2 /* HotKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC34D71C905B4D004177E2 /* HotKey.swift */; };
@@ -59,6 +60,7 @@
 		099F29FF246D091400992925 /* ModifierEventHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierEventHandler.swift; sourceTree = "<group>"; };
 		099F2A04246D094500992925 /* ModifierEventHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierEventHandlerTests.swift; sourceTree = "<group>"; };
 		FA3AA2152315A6A3007EAA1F /* CollectionExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionExtensionTests.swift; sourceTree = "<group>"; };
+		FADEA45924796103003AEC83 /* v3_1_0KeyCombo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = v3_1_0KeyCombo.swift; sourceTree = "<group>"; };
 		FAEC34AF1C9059DF004177E2 /* Magnet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Magnet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FAEC34B21C9059DF004177E2 /* Magnet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Magnet.h; sourceTree = "<group>"; };
 		FAEC34B41C9059DF004177E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 			isa = PBXGroup;
 			children = (
 				099F29F9246CFA9500992925 /* v2_0_0KeyCombo.swift */,
+				FADEA45924796103003AEC83 /* v3_1_0KeyCombo.swift */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -319,6 +322,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FADEA45A24796103003AEC83 /* v3_1_0KeyCombo.swift in Sources */,
 				099F2A07246D094500992925 /* ModifierEventHandlerTests.swift in Sources */,
 				090077D4245D449F0099B20A /* KeyComboTests.swift in Sources */,
 				099F29FA246CFA9500992925 /* v2_0_0KeyCombo.swift in Sources */,

--- a/Lib/MagnetTests/Fixtures/v3_1_0KeyCombo.swift
+++ b/Lib/MagnetTests/Fixtures/v3_1_0KeyCombo.swift
@@ -1,0 +1,79 @@
+// 
+//  v3_1_0KeyCombo.swift
+//
+//  MagnetTests
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+// 
+//  Copyright © 2015-2020 Clipy Project.
+//
+
+import Foundation
+import Sauce
+
+// swiftlint:disable type_name
+// ref: https://github.com/Clipy/Magnet/blob/v3.1.0/Lib/Magnet/KeyCombo.swift
+final class v3_1_0KeyCombo: NSObject, NSCoding, Codable {
+
+    // MARK: - Properties
+    public let key: Key
+    public let modifiers: Int
+    public let doubledModifiers: Bool
+    public var QWERTYKeyCode: Int {
+        guard !doubledModifiers else { return 0 }
+        return Int(key.QWERTYKeyCode)
+    }
+
+    // MARK: - Initialize
+    init(key: Key, modifiers: Int, doubledModifiers: Bool) {
+        self.key = key
+        self.modifiers = modifiers
+        self.doubledModifiers = doubledModifiers
+    }
+
+    public init?(coder aDecoder: NSCoder) {
+        self.doubledModifiers = aDecoder.decodeBool(forKey: CodingKeys.doubledModifiers.rawValue)
+        if doubledModifiers {
+            self.key = .a
+        } else {
+            let QWERTYKeyCode = aDecoder.decodeInteger(forKey: CodingKeys.QWERTYKeyCode.rawValue)
+            guard let key = Key(QWERTYKeyCode: QWERTYKeyCode) else { return nil }
+            self.key = key
+        }
+        self.modifiers = aDecoder.decodeInteger(forKey: CodingKeys.modifiers.rawValue)
+    }
+
+    public func encode(with aCoder: NSCoder) {
+        aCoder.encode(QWERTYKeyCode, forKey: CodingKeys.QWERTYKeyCode.rawValue)
+        aCoder.encode(modifiers, forKey: CodingKeys.modifiers.rawValue)
+        aCoder.encode(doubledModifiers, forKey: CodingKeys.doubledModifiers.rawValue)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.doubledModifiers = try container.decode(Bool.self, forKey: .doubledModifiers)
+        if doubledModifiers {
+            self.key = .a
+        } else {
+            let QWERTYKeyCode = try container.decode(Int.self, forKey: .QWERTYKeyCode)
+            guard let key = Key(QWERTYKeyCode: QWERTYKeyCode) else { throw NSError() }
+            self.key = key
+        }
+        self.modifiers = try container.decode(Int.self, forKey: .modifiers)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(QWERTYKeyCode, forKey: .QWERTYKeyCode)
+        try container.encode(modifiers, forKey: .modifiers)
+        try container.encode(doubledModifiers, forKey: .doubledModifiers)
+    }
+
+    // MARK: - Coding Keys
+    private enum CodingKeys: String, CodingKey {
+        case QWERTYKeyCode
+        case modifiers
+        case doubledModifiers
+    }
+
+}

--- a/Lib/MagnetTests/KeyComboTests.swift
+++ b/Lib/MagnetTests/KeyComboTests.swift
@@ -9,6 +9,7 @@
 //
 
 import XCTest
+import Sauce
 import Carbon
 @testable import Magnet
 
@@ -17,109 +18,154 @@ final class KeyComboTests: XCTestCase {
     // MARK: - Tests
     func testFunctionInitializer() {
         var keyCombo: KeyCombo?
+        // F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [])
         XCTAssertNotNil(keyCombo)
+        // Shift + Control + Comman + Option + F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [.shift, .control, .command, .option])
         XCTAssertNotNil(keyCombo)
     }
 
     func testDoubledTapKeyComboInitializer() {
         var keyCombo: KeyCombo?
+        // Shift double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .shift)
         XCTAssertNotNil(keyCombo)
+        // Empty double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: [])
         XCTAssertNil(keyCombo)
+        // Shift + Control double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: [.shift, .command])
         XCTAssertNil(keyCombo)
+        // Function double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: [.function])
         XCTAssertNil(keyCombo)
     }
 
     func testDoubledTapKeyComboCharacter() {
         var keyCombo: KeyCombo?
+        // Shift double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .shift)
         XCTAssertEqual(keyCombo?.characters, "")
+        // Control double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .control)
         XCTAssertEqual(keyCombo?.characters, "")
+        // Command double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .command)
         XCTAssertEqual(keyCombo?.characters, "")
+        // Option double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .option)
         XCTAssertEqual(keyCombo?.characters, "")
     }
 
     func testCharacter() {
         var keyCombo: KeyCombo?
+        // Command + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.command])
         XCTAssertEqual(keyCombo?.characters, "a")
+        // Shift + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.shift])
         XCTAssertEqual(keyCombo?.characters, "A")
+        // Option + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.option])
         XCTAssertEqual(keyCombo?.characters, "å")
+        // Option + Shift + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.option, .shift])
         XCTAssertEqual(keyCombo?.characters, "Å")
+        // Option + Shift + 1
         keyCombo = KeyCombo(key: .one, cocoaModifiers: [.option, .shift])
         XCTAssertEqual(keyCombo?.characters, "⁄")
+        // Option + Shift + KeyPad 1
+        keyCombo = KeyCombo(key: .keypadOne, cocoaModifiers: [.option, .shift])
+        XCTAssertEqual(keyCombo?.characters, "1")
+        // Option + ;
         keyCombo = KeyCombo(key: .semicolon, cocoaModifiers: [.option])
         XCTAssertEqual(keyCombo?.characters, "…")
+        // Shift + F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [.shift])
         XCTAssertEqual(keyCombo?.characters, "F1")
+        // Option double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .option)
         XCTAssertEqual(keyCombo?.characters, "")
     }
 
     func testKeyEquivalent() {
         var keyCombo: KeyCombo?
+        // Command + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.command])
         XCTAssertEqual(keyCombo?.keyEquivalent, "a")
+        // Shift + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.shift])
         XCTAssertEqual(keyCombo?.keyEquivalent, "A")
+        // Option + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.option])
         XCTAssertEqual(keyCombo?.keyEquivalent, "a")
+        // Option + Shift + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.option, .shift])
         XCTAssertEqual(keyCombo?.keyEquivalent, "A")
+        // Option + Shift + 1
         keyCombo = KeyCombo(key: .one, cocoaModifiers: [.option, .shift])
         XCTAssertEqual(keyCombo?.keyEquivalent, "1")
+        // Option + Shift + Keypad 1
+        keyCombo = KeyCombo(key: .keypadOne, cocoaModifiers: [.option, .shift])
+        XCTAssertEqual(keyCombo?.keyEquivalent, "1")
+        // Option + ;
         keyCombo = KeyCombo(key: .semicolon, cocoaModifiers: [.option])
         XCTAssertEqual(keyCombo?.keyEquivalent, ";")
+        // Shift + F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [.shift])
         XCTAssertEqual(keyCombo?.keyEquivalent, "F1")
+        // Option double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .option)
         XCTAssertEqual(keyCombo?.keyEquivalent, "")
     }
 
     func testKeyEquivalentModifierMaskString() {
         var keyCombo: KeyCombo?
+        // Shift + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.shift])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⇧")
+        // Control + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.control])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⌃")
+        // Command + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.command])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⌘")
+        // Option + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.option])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⌥")
+        // Shift + Control + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.shift, .control])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⌃⇧")
+        // Shift + Control + Option + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.shift, .control, .option])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⌃⌥⇧")
+        // Command + Option + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.command, .option])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⌥⌘")
+        // Command + Shift + Option + Control + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.command, .shift, .option, .control])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⌃⌥⇧⌘")
+        // Command + Option + Function + CapsLock + NumericPad + Help + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.command, .option, .function, .capsLock, .numericPad, .help])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⌥⌘")
+        // F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "")
+        // Command + F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [.command])
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⌘")
+        // Shift Double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .shift)
         XCTAssertEqual(keyCombo?.keyEquivalentModifierMaskString, "⇧")
     }
 
-    func testNSCodingMigrationV3() {
+    func testNSCodingMigrationV3_0() {
         var oldKeyCombo: v2_0_0KeyCombo?
         var archivedData: Data?
         var unarchivedKeyCombo: KeyCombo?
         NSKeyedUnarchiver.setClass(KeyCombo.self, forClassName: "MagnetTests.v2_0_0KeyCombo")
+        // Shift + v
         oldKeyCombo = v2_0_0KeyCombo(keyCode: kVK_ANSI_V, modifiers: shiftKey, doubledModifiers: false)
         archivedData = NSKeyedArchiver.archivedData(withRootObject: oldKeyCombo!)
         unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
@@ -127,6 +173,7 @@ final class KeyComboTests: XCTestCase {
         XCTAssertEqual(unarchivedKeyCombo?.key, .v)
         XCTAssertEqual(unarchivedKeyCombo?.modifiers, shiftKey)
         XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+        // F3
         oldKeyCombo = v2_0_0KeyCombo(keyCode: kVK_F3, modifiers: Int(NSEvent.ModifierFlags.function.rawValue), doubledModifiers: false)
         archivedData = NSKeyedArchiver.archivedData(withRootObject: oldKeyCombo!)
         unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
@@ -134,6 +181,7 @@ final class KeyComboTests: XCTestCase {
         XCTAssertEqual(unarchivedKeyCombo?.key, .f3)
         XCTAssertEqual(unarchivedKeyCombo?.modifiers, Int(NSEvent.ModifierFlags.function.rawValue))
         XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+        // Control double tap
         oldKeyCombo = v2_0_0KeyCombo(keyCode: 0, modifiers: controlKey, doubledModifiers: true)
         archivedData = NSKeyedArchiver.archivedData(withRootObject: oldKeyCombo!)
         unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
@@ -141,33 +189,96 @@ final class KeyComboTests: XCTestCase {
         XCTAssertEqual(unarchivedKeyCombo?.key, .a)
         XCTAssertEqual(unarchivedKeyCombo?.modifiers, controlKey)
         XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, true)
+        // Shift + @
+        oldKeyCombo = v2_0_0KeyCombo(keyCode: Int(Key.atSign.QWERTYKeyCode), modifiers: shiftKey, doubledModifiers: false)
+        archivedData = NSKeyedArchiver.archivedData(withRootObject: oldKeyCombo!)
+        unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .leftBracket)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, shiftKey)
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+    }
+
+    func testNSCodingMigrationV3_1() {
+        var oldKeyCombo: v3_1_0KeyCombo?
+        var archivedData: Data?
+        var unarchivedKeyCombo: KeyCombo?
+        NSKeyedUnarchiver.setClass(KeyCombo.self, forClassName: "MagnetTests.v3_1_0KeyCombo")
+        // Shift + v
+        oldKeyCombo = v3_1_0KeyCombo(key: .v, modifiers: shiftKey, doubledModifiers: false)
+        archivedData = NSKeyedArchiver.archivedData(withRootObject: oldKeyCombo!)
+        unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .v)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, shiftKey)
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+        // F3
+        oldKeyCombo = v3_1_0KeyCombo(key: .f3, modifiers: Int(NSEvent.ModifierFlags.function.rawValue), doubledModifiers: false)
+        archivedData = NSKeyedArchiver.archivedData(withRootObject: oldKeyCombo!)
+        unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .f3)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, Int(NSEvent.ModifierFlags.function.rawValue))
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+        // Control double tap
+        oldKeyCombo = v3_1_0KeyCombo(key: .a, modifiers: controlKey, doubledModifiers: true)
+        archivedData = NSKeyedArchiver.archivedData(withRootObject: oldKeyCombo!)
+        unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .a)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, controlKey)
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, true)
+        // Shift + @
+        oldKeyCombo = v3_1_0KeyCombo(key: .atSign, modifiers: shiftKey, doubledModifiers: false)
+        archivedData = NSKeyedArchiver.archivedData(withRootObject: oldKeyCombo!)
+        unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .leftBracket)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, shiftKey)
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
     }
 
     func testNSCoding() {
         var keyCombo: KeyCombo?
         var archivedData: Data?
         var unarchivedKeyCombo: KeyCombo?
+        // Shift + Control + c
         keyCombo = KeyCombo(key: .c, cocoaModifiers: [.shift, .control])
         archivedData = NSKeyedArchiver.archivedData(withRootObject: keyCombo!)
         unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
         XCTAssertNotNil(unarchivedKeyCombo)
         XCTAssertEqual(keyCombo, unarchivedKeyCombo)
+        // F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [])
         archivedData = NSKeyedArchiver.archivedData(withRootObject: keyCombo!)
         unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
         XCTAssertNotNil(unarchivedKeyCombo)
         XCTAssertEqual(keyCombo, unarchivedKeyCombo)
+        // Option double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: [.option])
+        archivedData = NSKeyedArchiver.archivedData(withRootObject: keyCombo!)
+        unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(keyCombo, unarchivedKeyCombo)
+        // Shift + @
+        keyCombo = KeyCombo(key: .atSign, cocoaModifiers: [.shift])
+        archivedData = NSKeyedArchiver.archivedData(withRootObject: keyCombo!)
+        unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(keyCombo, unarchivedKeyCombo)
+        // Control + [
+        keyCombo = KeyCombo(key: .leftBracket, cocoaModifiers: [.control])
         archivedData = NSKeyedArchiver.archivedData(withRootObject: keyCombo!)
         unarchivedKeyCombo = NSKeyedUnarchiver.unarchiveObject(with: archivedData!) as? KeyCombo
         XCTAssertNotNil(unarchivedKeyCombo)
         XCTAssertEqual(keyCombo, unarchivedKeyCombo)
     }
 
-    func testCodableMigrationV3() throws {
+    func testCodableMigrationV3_0() throws {
         var oldKeyCombo: v2_0_0KeyCombo?
         var archivedData: Data?
         var unarchivedKeyCombo: KeyCombo?
+        // Shift + v
         oldKeyCombo = v2_0_0KeyCombo(keyCode: kVK_ANSI_V, modifiers: shiftKey, doubledModifiers: false)
         archivedData = try JSONEncoder().encode(oldKeyCombo!)
         unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
@@ -175,6 +286,7 @@ final class KeyComboTests: XCTestCase {
         XCTAssertEqual(unarchivedKeyCombo?.key, .v)
         XCTAssertEqual(unarchivedKeyCombo?.modifiers, shiftKey)
         XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+        // F3
         oldKeyCombo = v2_0_0KeyCombo(keyCode: kVK_F3, modifiers: Int(NSEvent.ModifierFlags.function.rawValue), doubledModifiers: false)
         archivedData = try JSONEncoder().encode(oldKeyCombo!)
         unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
@@ -182,6 +294,7 @@ final class KeyComboTests: XCTestCase {
         XCTAssertEqual(unarchivedKeyCombo?.key, .f3)
         XCTAssertEqual(unarchivedKeyCombo?.modifiers, Int(NSEvent.ModifierFlags.function.rawValue))
         XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+        // Control double tap
         oldKeyCombo = v2_0_0KeyCombo(keyCode: 0, modifiers: controlKey, doubledModifiers: true)
         archivedData = try JSONEncoder().encode(oldKeyCombo!)
         unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
@@ -189,23 +302,84 @@ final class KeyComboTests: XCTestCase {
         XCTAssertEqual(unarchivedKeyCombo?.key, .a)
         XCTAssertEqual(unarchivedKeyCombo?.modifiers, controlKey)
         XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, true)
+        // Shift + @
+        oldKeyCombo = v2_0_0KeyCombo(keyCode: Int(Key.atSign.QWERTYKeyCode), modifiers: shiftKey, doubledModifiers: false)
+        archivedData = try JSONEncoder().encode(oldKeyCombo!)
+        unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .leftBracket)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, shiftKey)
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+    }
+
+    func testCodableMigrationV3_1() throws {
+        var oldKeyCombo: v3_1_0KeyCombo?
+        var archivedData: Data?
+        var unarchivedKeyCombo: KeyCombo?
+        // Shift + v
+        oldKeyCombo = v3_1_0KeyCombo(key: .v, modifiers: shiftKey, doubledModifiers: false)
+        archivedData = try JSONEncoder().encode(oldKeyCombo!)
+        unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .v)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, shiftKey)
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+        // F3
+        oldKeyCombo = v3_1_0KeyCombo(key: .f3, modifiers: Int(NSEvent.ModifierFlags.function.rawValue), doubledModifiers: false)
+        archivedData = try JSONEncoder().encode(oldKeyCombo!)
+        unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .f3)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, Int(NSEvent.ModifierFlags.function.rawValue))
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
+        // Control double tap
+        oldKeyCombo = v3_1_0KeyCombo(key: .a, modifiers: controlKey, doubledModifiers: true)
+        archivedData = try JSONEncoder().encode(oldKeyCombo!)
+        unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .a)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, controlKey)
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, true)
+        // Shift + @
+        oldKeyCombo = v3_1_0KeyCombo(key: .atSign, modifiers: shiftKey, doubledModifiers: false)
+        archivedData = try JSONEncoder().encode(oldKeyCombo!)
+        unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(unarchivedKeyCombo?.key, .leftBracket)
+        XCTAssertEqual(unarchivedKeyCombo?.modifiers, shiftKey)
+        XCTAssertEqual(unarchivedKeyCombo?.doubledModifiers, false)
     }
 
     func testCodable() throws {
         var keyCombo: KeyCombo?
         var archivedData: Data?
         var unarchivedKeyCombo: KeyCombo?
+        // Shift + Control + c
         keyCombo = KeyCombo(key: .c, cocoaModifiers: [.shift, .control])
         archivedData = try JSONEncoder().encode(keyCombo!)
         unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
         XCTAssertNotNil(unarchivedKeyCombo)
         XCTAssertEqual(keyCombo, unarchivedKeyCombo)
+        // F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [])
         archivedData = try JSONEncoder().encode(keyCombo!)
         unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
         XCTAssertNotNil(unarchivedKeyCombo)
         XCTAssertEqual(keyCombo, unarchivedKeyCombo)
+        // Option double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: [.option])
+        archivedData = try JSONEncoder().encode(keyCombo!)
+        unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(keyCombo, unarchivedKeyCombo)
+        // Shift + @
+        keyCombo = KeyCombo(key: .atSign, cocoaModifiers: [.shift])
+        archivedData = try JSONEncoder().encode(keyCombo!)
+        unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
+        XCTAssertNotNil(unarchivedKeyCombo)
+        XCTAssertEqual(keyCombo, unarchivedKeyCombo)
+        // Control + [
+        keyCombo = KeyCombo(key: .leftBracket, cocoaModifiers: [.control])
         archivedData = try JSONEncoder().encode(keyCombo!)
         unarchivedKeyCombo = try JSONDecoder().decode(KeyCombo.self, from: archivedData!)
         XCTAssertNotNil(unarchivedKeyCombo)


### PR DESCRIPTION
Change the save from `KeyCode` to `Key` to support keys that can only be typed with JIS keyboard, such as `@`.

This is because on JIS keyboard, `@` is in the `[` position of the English keyboard and `QWERTYKeyCode` is the same internally, so the information of `@` is lost when decoding.