### PR TITLE
initialize NSEvent.ModifierFlags from carbon modifiers

### DIFF
--- a/Lib/Magnet/Extensions/IntExtension.swift
+++ b/Lib/Magnet/Extensions/IntExtension.swift
@@ -12,25 +12,13 @@ import Cocoa
 import Carbon
 
 public extension Int {
-    @available(*, deprecated, renamed: "convertSupportCocoaModifiers")
+    @available(*, deprecated, renamed: "NSEvent.ModifierFlags.init(carbonModifiers:)")
     func convertSupportCococaModifiers() -> NSEvent.ModifierFlags {
         return convertSupportCocoaModifiers()
     }
 
+    @available(*, deprecated, renamed: "NSEvent.ModifierFlags.init(carbonModifiers:)")
     func convertSupportCocoaModifiers() -> NSEvent.ModifierFlags {
-        var cocoaFlags: NSEvent.ModifierFlags = NSEvent.ModifierFlags(rawValue: 0)
-        if (self & cmdKey) != 0 {
-            cocoaFlags.insert(.command)
-        }
-        if (self & optionKey) != 0 {
-            cocoaFlags.insert(.option)
-        }
-        if (self & controlKey) != 0 {
-            cocoaFlags.insert(.control)
-        }
-        if (self & shiftKey) != 0 {
-            cocoaFlags.insert(.shift)
-        }
-        return cocoaFlags
+        return NSEvent.ModifierFlags(carbonModifiers: self)
     }
 }

--- a/Lib/Magnet/Extensions/NSEventExtension.swift
+++ b/Lib/Magnet/Extensions/NSEventExtension.swift
@@ -15,6 +15,7 @@ public extension NSEvent.ModifierFlags {
     var containsSupportModifiers: Bool {
         return contains(.command) || contains(.option) || contains(.control) || contains(.shift) || contains(.function)
     }
+
     var isSingleFlags: Bool {
         let commandSelected = contains(.command)
         let optionSelected = contains(.option)
@@ -45,6 +46,42 @@ public extension NSEvent.ModifierFlags {
         return .shift
     }
 
+    func keyEquivalentStrings() -> [String] {
+        var strings = [String]()
+        if contains(.control) {
+            strings.append("⌃")
+        }
+        if contains(.option) {
+            strings.append("⌥")
+        }
+        if contains(.shift) {
+            strings.append("⇧")
+        }
+        if contains(.command) {
+            strings.append("⌘")
+        }
+        return strings
+    }
+}
+
+public extension NSEvent.ModifierFlags {
+    init(carbonModifiers: Int) {
+        var result = NSEvent.ModifierFlags(rawValue: 0)
+        if (carbonModifiers & cmdKey) != 0 {
+            result.insert(.command)
+        }
+        if (carbonModifiers & optionKey) != 0 {
+            result.insert(.option)
+        }
+        if (carbonModifiers & controlKey) != 0 {
+            result.insert(.control)
+        }
+        if (carbonModifiers & shiftKey) != 0 {
+            result.insert(.shift)
+        }
+        self = result
+    }
+
     func carbonModifiers(isSupportFunctionKey: Bool = false) -> Int {
         var carbonModifiers: Int = 0
         if contains(.command) {
@@ -63,22 +100,5 @@ public extension NSEvent.ModifierFlags {
             carbonModifiers |= Int(NSEvent.ModifierFlags.function.rawValue)
         }
         return carbonModifiers
-    }
-
-    func keyEquivalentStrings() -> [String] {
-        var strings = [String]()
-        if contains(.control) {
-            strings.append("⌃")
-        }
-        if contains(.option) {
-            strings.append("⌥")
-        }
-        if contains(.shift) {
-            strings.append("⇧")
-        }
-        if contains(.command) {
-            strings.append("⌘")
-        }
-        return strings
     }
 }


### PR DESCRIPTION
I didn't expect that the Carbon-modifiers-to-Cocoa-flags conversion was in `IntExtensions.swift` when I searched for this functionality in the new versions.

My suggestion is to make this an extension of `NSEvent.ModifierFlags` and provide a Carbon modifier flags based initializer. 

My argument:

- what you want to achieve is to create a `NSEvent.ModifierFlags` object, so an initializer fits wll
- It's just accidentally the case that Carbon modifiers are integers. Nobody (?) actually types a number and converts it, like `123.convertSupportCocoaModifiers()`

Cons:

- the initializer sounds like it converts *all* modifiers, not just the few supported ones for shortcuts

What do you think?