### PR TITLE
check-in dependency on Sauce

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Sauce",
+        "repositoryURL": "https://github.com/Clipy/Sauce",
+        "state": {
+          "branch": null,
+          "revision": "60508229cecbb915866151ebe9a0bf060a454c84",
+          "version": "2.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
When not checking in  `Package.resolved`, this will resolve on the client side (i.e., app devs) to any recent version. To make sure that no API conflicts exist, the resolved and known-to-be-good dependency should be checked in IMHO