### PR TITLE
ignore SwiftPM build products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
-Package.resolved
+# Package.resolved
 .build/
 .swiftpm/
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 ## Build generated
 build/
 DerivedData/
+Magnet.xcodeproj
 
 ## Various settings
 *.pbxuser
@@ -39,8 +40,9 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
-# Package.resolved
+Package.resolved
 .build/
+.swiftpm/
 
 # CocoaPods
 #
@@ -133,5 +135,3 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
-
-


### PR DESCRIPTION
Ignores the Xcode project that's generated by `swift package`, and `.swiftpm/` build products. 