### PR TITLE
Change keyEquivalent to show the typed character, not the QWERTY key cap label

### DIFF
--- a/Lib/Magnet/KeyCombo.swift
+++ b/Lib/Magnet/KeyCombo.swift
@@ -26,9 +26,21 @@ public final class KeyCombo: NSObject, NSCopying, NSCoding, Codable {
         guard !doubledModifiers else { return "" }
         return Sauce.shared.character(by: Int(Sauce.shared.keyCode(by: key)), carbonModifiers: modifiers) ?? ""
     }
+    /// The QWERTY key equivalent of this key combo's key code. Using a different keyboard layout, this
+    /// will not match the typed character. Use `keyEquivalent` instead.
     public var qwertyKeyLabel: String {
         guard !doubledModifiers else { return "" }
         let keyCode = Int(Sauce.shared.keyCode(by: key))
+        guard key.isAlphabet else { return Sauce.shared.character(by: keyCode, cocoaModifiers: []) ?? "" }
+        let modifiers = self.modifiers.convertSupportCocoaModifiers().filterNotShiftModifiers()
+        return Sauce.shared.character(by: keyCode, cocoaModifiers: modifiers) ?? ""
+    }
+    /// Character that would be typed in a text field when the user presses the key.
+    /// Use this for `NSMenuItem`'s `keyEquivalent` which expects the character and not the QWERTY key code.
+    public var keyEquivalent: String {
+        guard !doubledModifiers else { return "" }
+        // Not calling `Sauce.shared.keyCode` skips translation of the current layout
+        let keyCode = Int(key.QWERTYKeyCode)
         guard key.isAlphabet else { return Sauce.shared.character(by: keyCode, cocoaModifiers: []) ?? "" }
         let modifiers = self.modifiers.convertSupportCocoaModifiers().filterNotShiftModifiers()
         return Sauce.shared.character(by: keyCode, cocoaModifiers: modifiers) ?? ""

--- a/Lib/Magnet/KeyCombo.swift
+++ b/Lib/Magnet/KeyCombo.swift
@@ -22,18 +22,18 @@ public final class KeyCombo: NSObject, NSCopying, NSCoding, Codable {
         guard !doubledModifiers else { return 0 }
         return Int(key.QWERTYKeyCode)
     }
-    public var characters: String {
-        guard !doubledModifiers else { return "" }
-        return Sauce.shared.character(by: Int(Sauce.shared.keyCode(by: key)), carbonModifiers: modifiers) ?? ""
-    }
     /// The QWERTY key equivalent of this key combo's key code. Using a different keyboard layout, this
     /// will not match the typed character. Use `keyEquivalent` instead.
-    public var qwertyKeyLabel: String {
+    public var QWERTYKeyLabel: String {
         guard !doubledModifiers else { return "" }
         let keyCode = Int(Sauce.shared.keyCode(by: key))
         guard key.isAlphabet else { return Sauce.shared.character(by: keyCode, cocoaModifiers: []) ?? "" }
         let modifiers = self.modifiers.convertSupportCocoaModifiers().filterNotShiftModifiers()
         return Sauce.shared.character(by: keyCode, cocoaModifiers: modifiers) ?? ""
+    }
+    public var characters: String {
+        guard !doubledModifiers else { return "" }
+        return Sauce.shared.character(by: Int(Sauce.shared.keyCode(by: key)), carbonModifiers: modifiers) ?? ""
     }
     /// Character that would be typed in a text field when the user presses the key.
     /// Use this for `NSMenuItem`'s `keyEquivalent` which expects the character and not the QWERTY key code.

--- a/Lib/Magnet/KeyCombo.swift
+++ b/Lib/Magnet/KeyCombo.swift
@@ -26,7 +26,7 @@ public final class KeyCombo: NSObject, NSCopying, NSCoding, Codable {
         guard !doubledModifiers else { return "" }
         return Sauce.shared.character(by: Int(Sauce.shared.keyCode(by: key)), carbonModifiers: modifiers) ?? ""
     }
-    public var keyEquivalent: String {
+    public var qwertyKeyLabel: String {
         guard !doubledModifiers else { return "" }
         let keyCode = Int(Sauce.shared.keyCode(by: key))
         guard key.isAlphabet else { return Sauce.shared.character(by: keyCode, cocoaModifiers: []) ?? "" }

--- a/Lib/MagnetTests/KeyComboTests.swift
+++ b/Lib/MagnetTests/KeyComboTests.swift
@@ -93,31 +93,31 @@ final class KeyComboTests: XCTestCase {
         var keyCombo: KeyCombo?
         // Command + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.command])
-        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "a")
+        XCTAssertEqual(keyCombo?.QWERTYKeyLabel, "a")
         // Shift + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.shift])
-        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "A")
+        XCTAssertEqual(keyCombo?.QWERTYKeyLabel, "A")
         // Option + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.option])
-        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "a")
+        XCTAssertEqual(keyCombo?.QWERTYKeyLabel, "a")
         // Option + Shift + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.option, .shift])
-        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "A")
+        XCTAssertEqual(keyCombo?.QWERTYKeyLabel, "A")
         // Option + Shift + 1
         keyCombo = KeyCombo(key: .one, cocoaModifiers: [.option, .shift])
         // Option + Shift + Keypad 1
-        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "1")
+        XCTAssertEqual(keyCombo?.QWERTYKeyLabel, "1")
         keyCombo = KeyCombo(key: .keypadOne, cocoaModifiers: [.option, .shift])
-        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "1")
+        XCTAssertEqual(keyCombo?.QWERTYKeyLabel, "1")
         // Option + ;
         keyCombo = KeyCombo(key: .semicolon, cocoaModifiers: [.option])
-        XCTAssertEqual(keyCombo?.qwertyKeyLabel, ";")
+        XCTAssertEqual(keyCombo?.QWERTYKeyLabel, ";")
         // Shift + F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [.shift])
-        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "F1")
+        XCTAssertEqual(keyCombo?.QWERTYKeyLabel, "F1")
         // Option double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .option)
-        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "")
+        XCTAssertEqual(keyCombo?.QWERTYKeyLabel, "")
     }
 
     func testKeyEquivalentModifierMaskString() {

--- a/Lib/MagnetTests/KeyComboTests.swift
+++ b/Lib/MagnetTests/KeyComboTests.swift
@@ -93,31 +93,31 @@ final class KeyComboTests: XCTestCase {
         var keyCombo: KeyCombo?
         // Command + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.command])
-        XCTAssertEqual(keyCombo?.keyEquivalent, "a")
+        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "a")
         // Shift + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.shift])
-        XCTAssertEqual(keyCombo?.keyEquivalent, "A")
+        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "A")
         // Option + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.option])
-        XCTAssertEqual(keyCombo?.keyEquivalent, "a")
+        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "a")
         // Option + Shift + a
         keyCombo = KeyCombo(key: .a, cocoaModifiers: [.option, .shift])
-        XCTAssertEqual(keyCombo?.keyEquivalent, "A")
+        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "A")
         // Option + Shift + 1
         keyCombo = KeyCombo(key: .one, cocoaModifiers: [.option, .shift])
-        XCTAssertEqual(keyCombo?.keyEquivalent, "1")
         // Option + Shift + Keypad 1
+        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "1")
         keyCombo = KeyCombo(key: .keypadOne, cocoaModifiers: [.option, .shift])
-        XCTAssertEqual(keyCombo?.keyEquivalent, "1")
+        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "1")
         // Option + ;
         keyCombo = KeyCombo(key: .semicolon, cocoaModifiers: [.option])
-        XCTAssertEqual(keyCombo?.keyEquivalent, ";")
+        XCTAssertEqual(keyCombo?.qwertyKeyLabel, ";")
         // Shift + F1
         keyCombo = KeyCombo(key: .f1, cocoaModifiers: [.shift])
-        XCTAssertEqual(keyCombo?.keyEquivalent, "F1")
+        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "F1")
         // Option double tap
         keyCombo = KeyCombo(doubledCocoaModifiers: .option)
-        XCTAssertEqual(keyCombo?.keyEquivalent, "")
+        XCTAssertEqual(keyCombo?.qwertyKeyLabel, "")
     }
 
     func testKeyEquivalentModifierMaskString() {


### PR DESCRIPTION
Magnet does a great job translating the character of the pressed key into a key code and a "physical" key label. This PR changes property names to avoid confusion:

- Renames the label of a `KeyCombo` that corresponds to a QWERTY keyboard key to `qwertyKeyLabel`
- Changed `keyEquivalent` to produce a String that corresponds to the actual text character that results from pressing the key, which is needed for `NSMenuItem` and similar Cocoa/AppKit functionality

For users of `Magnet` that use `KeyCombo` for menu item shortcuts (like me), this means that the `NSMenuItem.keyEquivalent` needs to be updated when the keyboard layout is changed by the user, e.g. from QWERTY to DVORAK. This PR helps by aligning the meaning of "`keyEquivalent`" for this.