### PR TITLE
Update Sauce for Dvorak-QWERTY command keyboard support

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Clipy/Sauce" "v2.4.0"
+github "Clipy/Sauce" "v2.5.0"

--- a/Lib/Magnet/Extensions/NSEventExtension.swift
+++ b/Lib/Magnet/Extensions/NSEventExtension.swift
@@ -114,7 +114,7 @@ extension NSEvent {
     /// Returns a matching `KeyCombo` for the event, if the event is a keyboard event and the key is recognized.
     public var keyCombo: KeyCombo? {
         guard self.type.isKeyboardEvent else { return nil }
-        guard let key = Sauce.shared.key(for: Int(self.keyCode)) else { return nil }
+        guard let key = Sauce.shared.key(for: Int(self.keyCode), cocoaModifiers: self.modifierFlags) else { return nil }
         return KeyCombo(key: key, cocoaModifiers: self.modifierFlags)
     }
 }

--- a/Lib/Magnet/KeyCombo.swift
+++ b/Lib/Magnet/KeyCombo.swift
@@ -28,7 +28,7 @@ open class KeyCombo: NSObject, NSCopying, NSCoding, Codable {
     }
     public var keyEquivalent: String {
         guard !doubledModifiers else { return "" }
-        let keyCode = Int(Sauce.shared.keyCode(for: key))
+        let keyCode = Int(Sauce.shared.keyCode(for: key, carbonModifiers: modifiers))
         guard key.isAlphabet else { return Sauce.shared.character(for: keyCode, cocoaModifiers: []) ?? "" }
         let modifiers = keyEquivalentModifierMask.filterNotShiftModifiers()
         return Sauce.shared.character(for: keyCode, cocoaModifiers: modifiers) ?? ""
@@ -41,7 +41,7 @@ open class KeyCombo: NSObject, NSCopying, NSCoding, Codable {
     }
     public var currentKeyCode: CGKeyCode {
         guard !doubledModifiers else { return 0 }
-        return Sauce.shared.keyCode(for: key)
+        return Sauce.shared.keyCode(for: key, carbonModifiers: modifiers)
     }
 
     // MARK: - Initialize

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Magnet"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Clipy/Sauce", .upToNextMinor(from: "2.4.0")),
+        .package(url: "https://github.com/Clipy/Sauce", .upToNextMinor(from: "2.5.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- update Sauce from `v2.4.0` to `v2.5.0` for the latest keyboard layout mapping behavior
- pass modifier information when resolving keys from `NSEvent`
- use modifier-aware key code lookup in `KeyCombo` so Dvorak-QWERTY command shortcuts map correctly

## Why
Dvorak-QWERTY command keyboard layouts require key resolution that takes command-related modifiers into account. The previous Sauce API usage did not pass modifier context, so command shortcuts could resolve to the wrong key code or key mapping.

## Impact
Command-based shortcuts on Dvorak-QWERTY layouts now follow the updated Sauce behavior while preserving the existing handling for other layouts.

## Validation
- `swift test`
