### PR TITLE
Support hotkey re-registration on keyboard key code changes

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -24,7 +24,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                             keyCombo: keyCombo,
                             target: self,
                             action: #selector(AppDelegate.tappedHotKey),
-                            autoReRegisterOnKeyboardLayoutChange: true)
+                            autoReRegisterOnKeyboardKeyCodesChange: true)
         hotKey.register()
 
         // Shift + Control + A

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -23,7 +23,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let hotKey = HotKey(identifier: "CommandControlB",
                             keyCombo: keyCombo,
                             target: self,
-                            action: #selector(AppDelegate.tappedHotKey))
+                            action: #selector(AppDelegate.tappedHotKey),
+                            autoReRegisterOnKeyboardLayoutChange: true)
         hotKey.register()
 
         // Shift + Control + A

--- a/Lib/Magnet/HotKey.swift
+++ b/Lib/Magnet/HotKey.swift
@@ -12,7 +12,6 @@ import Cocoa
 import Carbon
 
 open class HotKey: NSObject {
-
     // MARK: - Properties
     public let identifier: String
     public let keyCombo: KeyCombo
@@ -20,9 +19,21 @@ open class HotKey: NSObject {
     public let target: AnyObject?
     public let action: Selector?
     public let actionQueue: ActionQueue
+    /// When enabled, Magnet auto re-registers this hot key after keyboard layout changes
+    /// if the KeyCode that was registered no longer matches the KeyCode for the
+    /// current layout.
+    ///
+    /// This is useful because macOS registers the layout-specific KeyCode that is
+    /// current at registration time.
+    /// For example, registering `v` uses KeyCode `9` on a QWERTY layout,
+    /// but KeyCode `47` on a Dvorak layout. If the keyboard
+    /// layout changes later, the registered hot key may no longer point to the
+    /// intended physical key unless it is registered again.
+    public let autoReRegisterOnKeyboardLayoutChange: Bool
 
     var hotKeyId: UInt32?
     var hotKeyRef: EventHotKeyRef?
+    var registeredKeyCode: CGKeyCode?
 
     // MARK: - Enum Value
     public enum ActionQueue {
@@ -42,26 +53,40 @@ open class HotKey: NSObject {
     }
 
     // MARK: - Initialize
-    public init(identifier: String, keyCombo: KeyCombo, target: AnyObject, action: Selector, actionQueue: ActionQueue = .main) {
+    public init(
+        identifier: String,
+        keyCombo: KeyCombo,
+        target: AnyObject,
+        action: Selector,
+        actionQueue: ActionQueue = .main,
+        autoReRegisterOnKeyboardLayoutChange: Bool = false
+    ) {
         self.identifier = identifier
         self.keyCombo = keyCombo
         self.callback = nil
         self.target = target
         self.action = action
         self.actionQueue = actionQueue
+        self.autoReRegisterOnKeyboardLayoutChange = autoReRegisterOnKeyboardLayoutChange
         super.init()
     }
 
-    public init(identifier: String, keyCombo: KeyCombo, actionQueue: ActionQueue = .main, handler: @escaping ((HotKey) -> Void)) {
+    public init(
+        identifier: String,
+        keyCombo: KeyCombo,
+        actionQueue: ActionQueue = .main,
+        autoReRegisterOnKeyboardLayoutChange: Bool = false,
+        handler: @escaping ((HotKey) -> Void)
+    ) {
         self.identifier = identifier
         self.keyCombo = keyCombo
         self.callback = handler
         self.target = nil
         self.action = nil
         self.actionQueue = actionQueue
+        self.autoReRegisterOnKeyboardLayoutChange = autoReRegisterOnKeyboardLayoutChange
         super.init()
     }
-
 }
 
 // MARK: - Invoke
@@ -102,6 +127,7 @@ extension HotKey {
 
         return self.identifier == hotKey.identifier &&
                self.keyCombo == hotKey.keyCombo &&
+               self.autoReRegisterOnKeyboardLayoutChange == hotKey.autoReRegisterOnKeyboardLayoutChange &&
                self.hotKeyId == hotKey.hotKeyId &&
                self.hotKeyRef == hotKey.hotKeyRef
     }

--- a/Lib/Magnet/HotKey.swift
+++ b/Lib/Magnet/HotKey.swift
@@ -19,17 +19,17 @@ open class HotKey: NSObject {
     public let target: AnyObject?
     public let action: Selector?
     public let actionQueue: ActionQueue
-    /// When enabled, Magnet auto re-registers this hot key after keyboard layout changes
-    /// if the KeyCode that was registered no longer matches the KeyCode for the
-    /// current layout.
+    /// When enabled, Magnet auto re-registers this hot key after keyboard key code
+    /// changes if the KeyCode that was registered no longer matches the KeyCode for
+    /// the current input source.
     ///
     /// This is useful because macOS registers the layout-specific KeyCode that is
     /// current at registration time.
     /// For example, registering `v` uses KeyCode `9` on a QWERTY layout,
-    /// but KeyCode `47` on a Dvorak layout. If the keyboard
-    /// layout changes later, the registered hot key may no longer point to the
-    /// intended physical key unless it is registered again.
-    public let autoReRegisterOnKeyboardLayoutChange: Bool
+    /// but KeyCode `47` on a Dvorak layout. If the selected keyboard key codes
+    /// change later, the registered hot key may no longer point to the intended
+    /// physical key unless it is registered again.
+    public let autoReRegisterOnKeyboardKeyCodesChange: Bool
 
     var hotKeyId: UInt32?
     var hotKeyRef: EventHotKeyRef?
@@ -59,7 +59,7 @@ open class HotKey: NSObject {
         target: AnyObject,
         action: Selector,
         actionQueue: ActionQueue = .main,
-        autoReRegisterOnKeyboardLayoutChange: Bool = false
+        autoReRegisterOnKeyboardKeyCodesChange: Bool = false
     ) {
         self.identifier = identifier
         self.keyCombo = keyCombo
@@ -67,7 +67,7 @@ open class HotKey: NSObject {
         self.target = target
         self.action = action
         self.actionQueue = actionQueue
-        self.autoReRegisterOnKeyboardLayoutChange = autoReRegisterOnKeyboardLayoutChange
+        self.autoReRegisterOnKeyboardKeyCodesChange = autoReRegisterOnKeyboardKeyCodesChange
         super.init()
     }
 
@@ -75,7 +75,7 @@ open class HotKey: NSObject {
         identifier: String,
         keyCombo: KeyCombo,
         actionQueue: ActionQueue = .main,
-        autoReRegisterOnKeyboardLayoutChange: Bool = false,
+        autoReRegisterOnKeyboardKeyCodesChange: Bool = false,
         handler: @escaping ((HotKey) -> Void)
     ) {
         self.identifier = identifier
@@ -84,7 +84,7 @@ open class HotKey: NSObject {
         self.target = nil
         self.action = nil
         self.actionQueue = actionQueue
-        self.autoReRegisterOnKeyboardLayoutChange = autoReRegisterOnKeyboardLayoutChange
+        self.autoReRegisterOnKeyboardKeyCodesChange = autoReRegisterOnKeyboardKeyCodesChange
         super.init()
     }
 }
@@ -127,7 +127,7 @@ extension HotKey {
 
         return self.identifier == hotKey.identifier &&
                self.keyCombo == hotKey.keyCombo &&
-               self.autoReRegisterOnKeyboardLayoutChange == hotKey.autoReRegisterOnKeyboardLayoutChange &&
+               self.autoReRegisterOnKeyboardKeyCodesChange == hotKey.autoReRegisterOnKeyboardKeyCodesChange &&
                self.hotKeyId == hotKey.hotKeyId &&
                self.hotKeyRef == hotKey.hotKeyRef
     }

--- a/Lib/Magnet/HotKeyCenter.swift
+++ b/Lib/Magnet/HotKeyCenter.swift
@@ -10,9 +10,9 @@
 
 import Cocoa
 import Carbon
+import Sauce
 
 open class HotKeyCenter {
-
     // MARK: - Properties
     public static let shared = HotKeyCenter()
 
@@ -27,16 +27,16 @@ open class HotKeyCenter {
         self.notificationCenter = notificationCenter
         installHotKeyPressedEventHandler()
         installModifiersChangedEventHandlerIfNeeded()
+        observeKeyboardLayoutChanges()
         observeApplicationTerminate()
     }
 
     deinit {
         notificationCenter.removeObserver(self)
     }
-
 }
 
-// MARK: - Register & Unregister
+// MARK: - Register
 extension HotKeyCenter {
     @discardableResult
     public func register(with hotKey: HotKey) -> Bool {
@@ -45,46 +45,40 @@ extension HotKeyCenter {
 
         hotKeys[hotKey.identifier] = hotKey
         guard !hotKey.keyCombo.doubledModifiers else { return true }
-        /*
-         *  Normal macOS shortcut
-         *
-         *  Discussion:
-         *    When registering a hotkey, a KeyCode that conforms to the
-         *    keyboard layout at the time of registration is registered.
-         *    To register a `v` on the QWERTY keyboard, `9` is registered,
-         *    and to register a `v` on the Dvorak keyboard, `47` is registered.
-         *    Therefore, if you change the keyboard layout after registering
-         *    a hot key, the hot key is not assigned to the correct key.
-         *    To solve this problem, you need to re-register the hotkeys
-         *    when you change the layout, but it's not supported by the
-         *    Apple Genuine app either, so it's not supported now.
-         */
+        guard registerEvent(with: hotKey) else {
+            unregister(with: hotKey)
+            return false
+        }
+
+        return true
+    }
+
+    @discardableResult
+    private func registerEvent(with hotKey: HotKey) -> Bool {
         let hotKeyId = EventHotKeyID(signature: UTGetOSTypeFromString("Magnet" as CFString), id: hotKeyCount)
         var carbonHotKey: EventHotKeyRef?
-        let error = RegisterEventHotKey(UInt32(hotKey.keyCombo.currentKeyCode),
+        let currentKeyCode = hotKey.keyCombo.currentKeyCode
+        let error = RegisterEventHotKey(UInt32(currentKeyCode),
                                         UInt32(hotKey.keyCombo.modifiers),
                                         hotKeyId,
                                         GetEventDispatcherTarget(),
                                         0,
                                         &carbonHotKey)
-        guard error == noErr else {
-            unregister(with: hotKey)
-            return false
-        }
+        guard error == noErr else { return false }
         hotKey.hotKeyId = hotKeyId.id
         hotKey.hotKeyRef = carbonHotKey
+        hotKey.registeredKeyCode = currentKeyCode
         hotKeyCount += 1
 
         return true
     }
+}
 
+// MARK: - Unregister
+extension HotKeyCenter {
     public func unregister(with hotKey: HotKey) {
-        if let carbonHotKey = hotKey.hotKeyRef {
-            UnregisterEventHotKey(carbonHotKey)
-        }
+        unregisterEvent(with: hotKey)
         hotKeys.removeValue(forKey: hotKey.identifier)
-        hotKey.hotKeyId = nil
-        hotKey.hotKeyRef = nil
     }
 
     @discardableResult
@@ -97,9 +91,18 @@ extension HotKeyCenter {
     public func unregisterAll() {
         hotKeys.forEach { unregister(with: $1) }
     }
+
+    private func unregisterEvent(with hotKey: HotKey) {
+        if let carbonHotKey = hotKey.hotKeyRef {
+            UnregisterEventHotKey(carbonHotKey)
+        }
+        hotKey.hotKeyId = nil
+        hotKey.hotKeyRef = nil
+        hotKey.registeredKeyCode = nil
+    }
 }
 
-// MARK: - Terminate
+// MARK: - Notifications
 extension HotKeyCenter {
     private func observeApplicationTerminate() {
         notificationCenter.addObserver(self,
@@ -108,8 +111,27 @@ extension HotKeyCenter {
                                        object: nil)
     }
 
+    private func observeKeyboardLayoutChanges() {
+        notificationCenter.addObserver(self,
+                                       selector: #selector(HotKeyCenter.selectedKeyboardKeyCodesChanged),
+                                       name: .SauceSelectedKeyboardKeyCodesChanged,
+                                       object: nil)
+    }
+
     @objc func applicationWillTerminate() {
         unregisterAll()
+    }
+
+    @objc func selectedKeyboardKeyCodesChanged() {
+        hotKeys.values
+            .filter { $0.autoReRegisterOnKeyboardLayoutChange }
+            .filter { !$0.keyCombo.doubledModifiers }
+            .forEach { hotKey in
+                let currentKeyCode = hotKey.keyCombo.currentKeyCode
+                guard hotKey.registeredKeyCode != currentKeyCode else { return }
+                unregisterEvent(with: hotKey)
+                registerEvent(with: hotKey)
+            }
     }
 }
 

--- a/Lib/Magnet/HotKeyCenter.swift
+++ b/Lib/Magnet/HotKeyCenter.swift
@@ -27,7 +27,7 @@ open class HotKeyCenter {
         self.notificationCenter = notificationCenter
         installHotKeyPressedEventHandler()
         installModifiersChangedEventHandlerIfNeeded()
-        observeKeyboardLayoutChanges()
+        observeKeyboardKeyCodesChanges()
         observeApplicationTerminate()
     }
 
@@ -111,7 +111,7 @@ extension HotKeyCenter {
                                        object: nil)
     }
 
-    private func observeKeyboardLayoutChanges() {
+    private func observeKeyboardKeyCodesChanges() {
         notificationCenter.addObserver(self,
                                        selector: #selector(HotKeyCenter.selectedKeyboardKeyCodesChanged),
                                        name: .SauceSelectedKeyboardKeyCodesChanged,
@@ -124,7 +124,7 @@ extension HotKeyCenter {
 
     @objc func selectedKeyboardKeyCodesChanged() {
         hotKeys.values
-            .filter { $0.autoReRegisterOnKeyboardLayoutChange }
+            .filter { $0.autoReRegisterOnKeyboardKeyCodesChange }
             .filter { !$0.keyCombo.doubledModifiers }
             .forEach { hotKey in
                 let currentKeyCode = hotKey.keyCombo.currentKeyCode


### PR DESCRIPTION
## Summary
- add an opt-in `autoReRegisterOnKeyboardKeyCodesChange` flag to `HotKey`
- observe `NSNotification.Name.SauceSelectedKeyboardKeyCodesChanged` and re-register only enabled hot keys whose stored key code no longer matches the current input source
- keep the QWERTY and Dvorak example in the API documentation so the reason for the option is explicit
- enable the option in the example app for the sample hot key

## Why
macOS registers the layout-specific key code that is current at registration time. For example, registering `v` uses KeyCode `9` on a QWERTY layout, but KeyCode `47` on a Dvorak layout. If the selected keyboard key codes change later, the registered hot key can stop pointing at the intended physical key unless it is registered again.

## Impact
Existing behavior is unchanged by default. Callers can opt in per hot key when they want automatic re-registration on keyboard key code changes.

## Validation
- `swift test`